### PR TITLE
regression test for after() XS stack handling bug

### DIFF
--- a/t/lib/LMU/Test/Functions.pm
+++ b/t/lib/LMU/Test/Functions.pm
@@ -499,6 +499,9 @@ sub test_after
         }
     );
     is_dying( sub { &after( 42, 4711 ); } );
+
+    @x = ( 1, after { /foo/ } qw(abc def) );
+    is_deeply(\@x, [ 1 ], "check XS implementation doesn't mess up stack");
 }
 
 # In the following, the @dummy variable is needed to circumvent


### PR DESCRIPTION
This provides the regression test you were looking for.

This test fails on older versions of perl, and Reini's fix in #13 fixes it.