### PR TITLE
Fix typo in Changes

### DIFF
--- a/Changes
+++ b/Changes
@@ -7,7 +7,7 @@ Revision history for Perl extension List-MoreUtils
 0.429_001	2020-10-05
     - fix failing installation in parallel make (Issue#38)
     - infrastructure improvements and tooling updates,
-      lot's of author tests with according fixes added
+      lots of author tests with according fixes added
     - added slide and slideatatime functions wished by SCHWERN
     - documentation fixes (PR#21, PR#33, PR#34, RT#126029, RT#132043, RT#132940)
 


### PR DESCRIPTION
Trivially changed "lot's" to "lots" in Changes.