### PR TITLE
documentation of apply: mention how $_ is used in BLOCK

### DIFF
--- a/lib/List/MoreUtils.pm
+++ b/lib/List/MoreUtils.pm
@@ -349,10 +349,11 @@ Evaluation of BLOCK will immediately stop at the second true value.
 
 =head3 apply BLOCK LIST
 
-Applies BLOCK to each item in LIST and returns a list of the values after BLOCK
-has been applied. In scalar context, the last element is returned.  This
-function is similar to C<map> but will not modify the elements of the input
-list:
+Applies BLOCK to each item ($_) in LIST and returns a list of the updated
+value of $_. In scalar context, the last element is returned.
+
+This function is similar to C<map> but will not modify the elements of
+the input list:
 
   my @list = (1 .. 4);
   my @mult = apply { $_ *= 2 } @list;


### PR DESCRIPTION
Hi,


I'd like to propose this change of documentation of `apply` function that I think improves two points:

1. `$_` is used in BLOCK
2. The returned list is a list of new `$_` but not a list of return values of BLOCK

The current documentation requires users to learn the conventional `$_` variable, but IMHO it'd be much friendly to new comers to mention `$_` in here, just like it is in the documentation of `map`.

Also, for users who are familiar with `map`, there are *2* differences but not just 1. `map` gathers the return values BLOCK while `apply` gathers the updated value of `$_` . It would also be nice to mentioned such behaviour expliictly instead of letting users to deduct from the example code.

